### PR TITLE
made mpad url distributor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ Authorization flow depends on `mpad.js` browser library. To show login button:
 (authorization URL) and `data-element` (login button ID)
 
 ```
-<script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+<script src="<<Insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
 ```
+
+Please refer to your distributor-specific documentation to find the correct url for the mpad.js `script src`
 
 After user interaction with Miracl system, user will be sent to `redirectUri` defined at
 creation of `MiraclClient` object.

--- a/sample-spark/src/main/resources/templates/index.pebble
+++ b/sample-spark/src/main/resources/templates/index.pebble
@@ -73,8 +73,9 @@
             {% endif %}
         </div>
     {% endif %}
+    <!--Please refer to your distributor-specific documentation to find the correct url for the mpad.js script src-->
     {% if retry or not authorized %}
-        <script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ authURL }}" data-element="btmpin"></script>
+        <script src="<<Insert correct mpad url here>>" data-authurl="{{ authURL }}" data-element="btmpin"></script>
     {% endif %}
 </div>
 </body>


### PR DESCRIPTION
This is to make the SDK repos distributor-neutral.

The instructions for the correct mpad.js url are found in the devdocs for each distributor.