### PR TITLE
Add proxy server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ To complete authorization pass query string received on `redirectUri` to
 token if authorization succeeded. Token is preserved in `session` so there
 is no need to save token elsewhere.
 
+### Proxy server support
+
+A proxy server can be used by calling the `useProxy(host, port)` method found in `MiraclClient`.
+Proxy support is handled by the standard [Java Networking API](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html).
+You can consult the included code samples to see how proxy server configuration can be passed into your application.
+
 ### Problems and exceptions
 
 Each call to `MiraclClient` can raise `MiraclException`. `MiraclException` can be

--- a/maas-sdk/src/main/java/com/miracl/maas_sdk/MiraclClient.java
+++ b/maas-sdk/src/main/java/com/miracl/maas_sdk/MiraclClient.java
@@ -97,6 +97,22 @@ public class MiraclClient
 			throw new MiraclSystemException(e);
 		}
 	}
+	
+	/**
+	 * Use a proxy for all out-going requests performed by the library.
+	 * 
+	 * If a proxy server is required, useProxy should be called immediately
+	 * after constructing a MiraclClient. Proxy settings are applied VM-wide.
+	 * The proxy will be used for both HTTP and HTTPS requests.
+	 * @param host Hostname for the proxy server, for example "localhost"
+	 * @param port Port for the proxy server
+	 */
+	public static void useProxy(String host, String port) {
+		System.setProperty("http.proxyHost", host);
+		System.setProperty("https.proxyHost", host);
+		System.setProperty("http.proxyPort", port);
+		System.setProperty("https.proxyPort", port);		
+	}
 
 	/**
 	 * @param url URL pointing to openid-configuration

--- a/maas-sdk/src/test/java/com/miracl/maas_sdk/MiraclClientTest.java
+++ b/maas-sdk/src/test/java/com/miracl/maas_sdk/MiraclClientTest.java
@@ -113,6 +113,16 @@ public class MiraclClientTest
 		Assert.assertEquals(id, "MOCK_USER");
 
 	}
+	
+	@Test
+	public static void testUseProxy() throws Exception {
+		MiraclClient.useProxy("localhost", "8888");
+		
+		Assert.assertEquals(System.getProperty("http.proxyHost"), "localhost");
+		Assert.assertEquals(System.getProperty("https.proxyHost"), "localhost");
+		Assert.assertEquals(System.getProperty("http.proxyPort"), "8888");
+		Assert.assertEquals(System.getProperty("https.proxyPort"), "8888");
+	}
 
 	//TODO: Remove when not needed - temporary workaround
 	private static void trustAllCertificatesNew()

--- a/sample-spark/src/main/java/com/miracl/maas_samples/SparkSample.java
+++ b/sample-spark/src/main/java/com/miracl/maas_samples/SparkSample.java
@@ -25,6 +25,7 @@ import static spark.Spark.port;
  */
 public class SparkSample
 {
+	
 	/**
 	 * Utility function to prepare model and view for page rendering.
 	 *
@@ -90,6 +91,11 @@ public class SparkSample
 		String clientId = config.get("client_id").asString();
 		String secret = config.get("secret").asString();
 		String redirectUri = config.get("redirect_uri").asString();
+		
+		boolean useProxy = config.getBoolean("use_proxy", false);
+		String proxyHost = config.getString("proxy_host", "localhost");
+		String proxyPort = config.getString("proxy_port", "8888");
+		
 		configStream.close();
 
 		// Prepare template engine
@@ -102,6 +108,9 @@ public class SparkSample
 
 		// Prepare Miracl client instance
 		MiraclClient miracl = new MiraclClient(clientId, secret, redirectUri);
+		if (useProxy) {
+			MiraclClient.useProxy(proxyHost, proxyPort);
+		}
 
 		// Main request handler - show login button or user data
 		get("/", (req, res) ->

--- a/sample-spark/src/main/resources/miracl.json
+++ b/sample-spark/src/main/resources/miracl.json
@@ -1,5 +1,8 @@
 {
   "client_id": "CLIENT_ID",
   "secret": "SECRET",
-  "redirect_uri": "REDIRECT_URI"
+  "redirect_uri": "REDIRECT_URI",
+  "use_proxy": false,
+  "proxy_host": "PROXY_HOST",
+  "proxy_port": "PROXY_PORT"
 }


### PR DESCRIPTION
The Java SDK now allows for proxy configuration. It can be done via the new `useProxy(host, port)` method in MiraclClient. The example application has been updated to make use of this new method, reading configuration data from the miracl.json file.

The actual proxy support comes natively with Java<sup>[1](#footnote1)</sup> - the committed changes simply allow setting the related properties. Please note that proxy configuration is applied and valid VM-wide: all requests sent by the application will be using the proxy server.

<a name="footnote1">1.</a> https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html