### PR TITLE
Add preroll ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # maas-sdk-java
 
 [![Master Build Status](https://secure.travis-ci.org/miracl/maas-sdk-java.png?branch=master)](https://travis-ci.org/miracl/maas-sdk-java?branch=master)
-[![Master Coverage Status](https://coveralls.io/repos/miracl/maas-sdk-java/badge.svg?branch=master&service=github)](https://coveralls.io/github/miracl/maas-sdk-java?branch=master)
+[![Master Coverage Status](https://coveralls.io/repos/github/miracl/maas-sdk-java/badge.svg?branch=master)](https://coveralls.io/github/miracl/maas-sdk-java?branch=master)
 
 * **category**:    SDK
 * **copyright**:   2016 MIRACL UK LTD

--- a/sample-spark/src/main/resources/templates/index.pebble
+++ b/sample-spark/src/main/resources/templates/index.pebble
@@ -28,7 +28,24 @@
             width: 100%;
             margin-bottom: 15px;
         }
+        #example-email{
+            margin-bottom: 20px;
+        }
     </style>
+
+    <script
+        src="https://code.jquery.com/jquery-3.1.1.slim.min.js"
+        integrity="sha256-/SIrNqv8h6QGKDuNoLGA4iret+kyesCkHGzVUUV0shc="
+        crossorigin="anonymous"></script>
+
+    <script type="application/javascript">
+        $(document).ready(function() {
+            $("input[type=email]").keyup(function() {
+                var email = $("input[type=email]").val();
+                $("#btmpin").attr("data-prerollid", email);
+            });
+        });
+    </script>
 </head>
 <body>
 <div class="container">
@@ -68,6 +85,14 @@
                 </div>
             {% else %}
                 <div class="col-md-12">
+                    <div class="col-md-8" id="example-email">
+                        <div class="form-group">
+                            <label for="example-email-input" class="col-xs-2 col-form-label">Log In As:</label>
+                            <div class="col-xs-10">
+                                <input class="form-control" type="email" id="example-email-input" placeholder="email address">
+                            </div>
+                        </div>
+                    </div>
                     <div id="btmpin"></div>
                 </div>
             {% endif %}


### PR DESCRIPTION
The sample has been updated to feature an email input field where the user can input her address to use as a preroll ID.

Additionally, README.md has been updated to use the correct URL to the coveralls.io unit test coverage badge.